### PR TITLE
bugfixes for put method 

### DIFF
--- a/src/main/java/org/springframework/data/rest/shell/commands/HttpCommands.java
+++ b/src/main/java/org/springframework/data/rest/shell/commands/HttpCommands.java
@@ -229,7 +229,7 @@ public class HttpCommands implements CommandMarker, ApplicationEventPublisherAwa
                  help = "The path to the resource.",
                  unspecifiedDefaultValue = "") PathOrRel path,
       @CliOption(key = "data",
-                 mandatory = true,
+                 mandatory = false,
                  help = "The JSON data to use as the resource.") String data,
       @CliOption(key = "from",
                  mandatory = false,
@@ -415,7 +415,7 @@ public class HttpCommands implements CommandMarker, ApplicationEventPublisherAwa
       output = numItems.get() + " files uploaded to the server using " + method;
     } else {
       Object body = readFile(fromFile);
-      String response = execute(HttpMethod.POST,
+      String response = execute(method,
                                 body,
                                 follow,
                                 outputPath);


### PR DESCRIPTION
- make the --data parameter not mandatory (so you can use --from)
- use the method parameter in readFileOrFiles not HTTPMETHOD.POST (for the single file case)
