### PR TITLE
Improvement to Basic Authentication command

### DIFF
--- a/src/main/java/org/springframework/data/rest/shell/commands/AuthCommands.java
+++ b/src/main/java/org/springframework/data/rest/shell/commands/AuthCommands.java
@@ -42,10 +42,10 @@ public class AuthCommands implements CommandMarker {
           help = "The username to use") String username,
       @CliOption(
           key = "password",
-          mandatory = true,
+          mandatory = false,
           help = "The password to use") String password) throws IOException {
 
-    String token = BASIC + Base64.encodeBase64String((username + ":" + password).getBytes());
+    String token = BASIC + Base64.encodeBase64String((username + ":" + ((password != null) ? password : "")).getBytes());
     configCmds.setHeader(AUTHORIZATION, token);
     return HEADER + token;
   }


### PR DESCRIPTION
This will allow to set BA user without specifying a password.

Some RESTful API authenticate user by token that is transferred as user name w/o password, e.g. https://stripe.com/docs/api#authentication
