### PR TITLE
Null pointer in links

### DIFF
--- a/src/main/java/org/springframework/data/rest/shell/commands/HttpCommands.java
+++ b/src/main/java/org/springframework/data/rest/shell/commands/HttpCommands.java
@@ -377,6 +377,9 @@ public class HttpCommands implements CommandMarker, ApplicationEventPublisherAwa
 			}
 			// Calling this method recursively results in hang, so just retry once.
 			response = restTemplate.execute(requestUri, method, helper, helper);
+		} catch(RuntimeException re) {
+			LOG.error(re.getMessage(), re);
+			throw re;
 		} finally {
 			restTemplate.setErrorHandler(origErrHandler);
 		}


### PR DESCRIPTION
I had a case where JSON object returned from API had a links parameter that is null. It took me a while to figure out the problem.

This commits should fix this problem and improve logging if error happens during parsing of result.
