### PR TITLE
Updated repositories in build.gradle for Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,11 +38,12 @@ project.targetCompatibility = 1.6
 
 // Repositories
 repositories {
-  //maven { url "http://repo.springsource.org/libs-snapshot" }
+  mavenLocal()
+  mavenCentral()
+  maven { url "http://repo.springsource.org/libs-snapshot" }
   //maven { url "http://repo.springsource.org/libs-milestone" }
   maven { url "http://repo.springsource.org/libs-release" }
   maven { url "http://spring-roo-repository.springsource.org/release" }
-  mavenLocal()
 }
 
 // Artifact Configuration


### PR DESCRIPTION
The build will complete with these gradle repository changes.

Unfortunately I still get known problem that SpringShell launches instead of RestShell. I tried to build the jbrisbin repo spring-shell instead of the offcial one, but I got an error during the gradlew build.

```
junit.framework.AssertionFailedError: Number of Converters is incorrect expected:<16> but was:<11>
    at junit.framework.Assert.fail(Assert.java:50)
    at junit.framework.Assert.failNotEquals(Assert.java:287)
    at junit.framework.Assert.assertEquals(Assert.java:67)
    at junit.framework.Assert.assertEquals(Assert.java:199)
    at org.springframework.shell.BootstrapTest.test(BootstrapTest.java:21)
```

Even after forcing the test to pass, the SpringShell launches instead of RestShell problem still exists.
