### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,9 @@ project.targetCompatibility = 1.6
 
 // Repositories
 repositories {
-  //maven { url "http://repo.springsource.org/libs-snapshot" }
-  //maven { url "http://repo.springsource.org/libs-milestone" }
-  maven { url "http://repo.springsource.org/libs-release" }
+  //maven { url "https://repo.springsource.org/libs-snapshot" }
+  //maven { url "https://repo.springsource.org/libs-milestone" }
+  maven { url "https://repo.springsource.org/libs-release" }
   maven { url "http://spring-roo-repository.springsource.org/release" }
   mavenLocal()
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://spring-roo-repository.springsource.org/release (404) migrated to:  
  http://spring-roo-repository.springsource.org/release ([https](https://spring-roo-repository.springsource.org/release) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-release migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).